### PR TITLE
Add microSD card to JumpDrive

### DIFF
--- a/initramfs/init_functions.sh
+++ b/initramfs/init_functions.sh
@@ -38,6 +38,8 @@ setup_usb_configfs() {
 		|| echo "  Couldn't create $CONFIGFS/g1/functions/$usb_rndis_function"
 	mkdir $CONFIGFS/g1/functions/"$usb_mass_storage_function" \
 		|| echo "  Couldn't create $CONFIGFS/g1/functions/$usb_mass_storage_function"
+	mkdir $CONFIGFS/g1/functions/"$usb_mass_storage_function/lun.1" \
+		|| echo "  Couldn't create $CONFIGFS/g1/functions/$usb_mass_storage_function/lun.1"
 
 	# Create configuration instance for the gadget
 	mkdir $CONFIGFS/g1/configs/c.1 \
@@ -54,9 +56,11 @@ setup_usb_configfs() {
 
 	# Set up mass storage to internal EMMC
 	echo $EMMC > $CONFIGFS/g1/functions/"$usb_mass_storage_function"/lun.0/file
+	echo $SD > $CONFIGFS/g1/functions/"$usb_mass_storage_function"/lun.1/file
 
 	# Rename the mass storage device
-	echo "JumpDrive" > $CONFIGFS/g1/functions/"$usb_mass_storage_function"/lun.0/inquiry_string
+	echo "JumpDrive eMMC" > $CONFIGFS/g1/functions/"$usb_mass_storage_function"/lun.0/inquiry_string
+	echo "JumpDrive microSD" > $CONFIGFS/g1/functions/"$usb_mass_storage_function"/lun.1/inquiry_string
 
 	# Link the rndis/mass_storage instance to the configuration
 	ln -s $CONFIGFS/g1/functions/"$usb_rndis_function" $CONFIGFS/g1/configs/c.1 \

--- a/src/info-pine64-pinephone.sh
+++ b/src/info-pine64-pinephone.sh
@@ -1,5 +1,6 @@
 PLATFORM=pine64-pinephone
 EMMC=/dev/mmcblk2
+SD=/dev/mmcblk0
 LED=pinephone\:red\:user
 TRIGGER=mmc2
 ERRORLINES=80

--- a/src/info-pine64-pinetab.sh
+++ b/src/info-pine64-pinetab.sh
@@ -1,2 +1,3 @@
 PLATFORM=pine64-pinetab
 EMMC=/dev/mmcblk2
+SD=/dev/mmcblk0


### PR DESCRIPTION
This change adds the microSD card as a mass storage device in Jumpdrive. This allows users to modify the contents of their SD card in addition to their eMMC. This could be useful when Jumpdrive becomes ubiquitous, and users want to reflash *all the things* on the fly.

If a card is not inserted, the error "sh: write error: No such file or directory" appears in init's logs. Init does not fail.