### PR TITLE
Add support for spawning shell over serial

### DIFF
--- a/initramfs/init
+++ b/initramfs/init
@@ -47,6 +47,7 @@ mknod /dev/tty c 5 0
 mdev -s
 
 # Finishing rescue setup
+start_serial_getty
 setup_usb_configfs
 start_udhcpd
 setup_telnetd

--- a/initramfs/init_functions.sh
+++ b/initramfs/init_functions.sh
@@ -128,6 +128,15 @@ start_udhcpd() {
 	udhcpd
 }
 
+start_serial_getty() {
+	if [ -n "$SERIAL_CON" ] && [ -n "$SERIAL_BAUD" ]; then
+		# Serial console isn't supposed to be quitted, so if task is finished, relaunch it.
+		sh -c "while true; do getty -l /bin/sh -n $SERIAL_BAUD $SERIAL_CON linux; done" &
+	else
+		echo "Not setting up serial shell, SERIAL_CON and/or SERIAL_BAUD is not defined."
+	fi
+}
+
 fatal_error() {
 	clear
 

--- a/src/busybox_config
+++ b/src/busybox_config
@@ -1,7 +1,7 @@
 #
 # Automatically generated make config: don't edit
 # Busybox version: 1.32.0.git
-# Mon Jun  1 02:58:12 2020
+# Mon Jun  1 20:37:44 2020
 #
 CONFIG_HAVE_DOT_CONFIG=y
 
@@ -525,7 +525,7 @@ CONFIG_FEATURE_DEFAULT_PASSWD_ALGO=""
 # CONFIG_DELUSER is not set
 # CONFIG_DELGROUP is not set
 # CONFIG_FEATURE_DEL_USER_FROM_GROUP is not set
-# CONFIG_GETTY is not set
+CONFIG_GETTY=y
 # CONFIG_LOGIN is not set
 # CONFIG_LOGIN_SESSION_AS_CHILD is not set
 # CONFIG_LOGIN_SCRIPTS is not set

--- a/src/info-pine64-pinephone.sh
+++ b/src/info-pine64-pinephone.sh
@@ -4,3 +4,5 @@ SD=/dev/mmcblk0
 LED=pinephone\:red\:user
 TRIGGER=mmc2
 ERRORLINES=80
+SERIAL_CON=ttyS0
+SERIAL_BAUD=115200

--- a/src/info-pine64-pinetab.sh
+++ b/src/info-pine64-pinetab.sh
@@ -1,3 +1,5 @@
 PLATFORM=pine64-pinetab
 EMMC=/dev/mmcblk2
 SD=/dev/mmcblk0
+SERIAL_CON=ttyS0
+SERIAL_BAUD=115200


### PR DESCRIPTION
Add support for #20. Confirmed working on the Pinetab.