### PR TITLE
Don't use grouped targets for the sunxi dtbs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ initramfs-%.gz: initramfs-%.cpio
 	@echo "GZ    $@"
 	@gzip < $< > $@
 	
-kernel-sunxi.gz dtbs/sunxi/sun50i-a64-pinephone.dtb dtbs/sunxi/sun50i-a64-pinetab.dtb &: src/linux_config_sunxi
+kernel-sunxi.gz: src/linux_config_sunxi
 	@echo "MAKE  kernel-sunxi.gz"
 	@mkdir -p build/linux-sunxi
 	@mkdir -p dtbs/sunxi
@@ -103,6 +103,10 @@ kernel-sunxi.gz dtbs/sunxi/sun50i-a64-pinephone.dtb dtbs/sunxi/sun50i-a64-pineta
 	@$(MAKE) -C src/linux O=../../build/linux-sunxi $(CROSS_FLAGS)
 	@cp build/linux-sunxi/arch/arm64/boot/Image.gz kernel-sunxi.gz
 	@cp build/linux-sunxi/arch/arm64/boot/dts/allwinner/*.dtb dtbs/sunxi/
+
+dtbs/sunxi/sun50i-a64-pinephone.dtb: kernel-sunxi.gz
+
+dtbs/sunxi/sun50i-a64-pinetab.dtb: kernel-sunxi.gz
 
 kernel-rockchip.gz: src/linux_config_rockchip src/linux-rockchip
 	@echo "MAKE  $@"


### PR DESCRIPTION
Grouped explicit targets (the &: syntax) indicate to Make that a single recipe, built once, produces all the indicated targets. In this case, the feature was being used to indicate that the kernel build also creates the needed dtbs for the sunxi devices.

Unfortunately, this feature was only introduced in GNU make 4.3 on January 27 2020. Most current or LTS (or current LTS) releases of distributions don't have this version of Make yet. For example, Ubuntu 20.04, Fedora 32, and Debian 10 (Buster) are still on GNU make 4.2 or older. When grouped targets are used on older versions of GNU make, it tries to run the same recipe once for each target. In this case, a 'make all' at the top level would run 'make -C src/linux ...' three times. This caused file locking problems when anything but 'make -j1' was used and made build times pretty long in any other case.

Fix this by changing the dtbs to dependency-only targets. Now GNU make <4.3 correctly intuits "I only need to build kernel-sunxi.gz once and will provide the dtbs, too" instead of "I need to build this kernel-sunxi.gz recipe three times: once for kernel-sunxi.gz, once for the two dtbs"