### PR TITLE
image with pinetab specific uboot-spl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ src/u-boot: u-boot-2020.04.tar.bz2
 	@echo "UNTAR u-boot"
 	@mkdir src/u-boot
 	@tar -xf u-boot-2020.04.tar.bz2 --strip-components 1 -C src/u-boot
-	@cd src/u-boot && patch -p1 < ../u-boot-pinephone.patch
+	@cd src/u-boot && patch -p1 < ../u-boot-pinephone.patch && patch -p1 -i ../0001-isun50i-a64-Add-PinePhone-DTS-and-defconfig.patch
 
 busybox-1.32.0.tar.bz2:
 	@echo "WGET  busybox"

--- a/Makefile
+++ b/Makefile
@@ -150,36 +150,55 @@ u-boot-rk3399.bin: build/atf/rk3399/bl31.elf src/u-boot
 	@BL31=../../../build/atf/rk3399/bl31.elf $(MAKE) -C src/u-boot O=../../build/u-boot/rk3399 $(CROSS_FLAGS_BOOT) all
 	@cp build/u-boot/rk3399/u-boot "$@"
 
-src/linux-rockchip:
+deps: linux-pinebook-pro-v5.6.tar.gz orange-pi-5.9-20201019-1553.tar.gz arm-trusted-firmware.tar.gz u-boot-2020.04.tar.bz2 busybox-1.32.0.tar.bz2
+
+src: deps src/linux-rockchip src/linux-sunxi src/arm-trusted-firmware src/u-boot src/busybox
+
+linux-pinebook-pro-v5.6.tar.gz:
 	@echo "WGET  linux-rockchip"
-	@mkdir src/linux-rockchip
 	@wget https://gitlab.manjaro.org/tsys/linux-pinebook-pro/-/archive/v5.6/linux-pinebook-pro-v5.6.tar.gz
-	@tar -xvf linux-pinebook-pro-v5.6.tar.gz --strip-components 1 -C src/linux-rockchip
 
-src/linux-sunxi:
+src/linux-rockchip: linux-pinebook-pro-v5.6.tar.gz
+	@echo "UNTAR linux-rockchip"
+	@mkdir src/linux-rockchip
+	@tar -xf linux-pinebook-pro-v5.6.tar.gz --strip-components 1 -C src/linux-rockchip
+
+orange-pi-5.9-20201019-1553.tar.gz:
 	@echo "WGET  linux-sunxi"
-	@mkdir src/linux-sunxi
 	@wget https://github.com/megous/linux/archive/orange-pi-5.9-20201019-1553.tar.gz
-	@tar -xvf orange-pi-5.9-20201019-1553.tar.gz --strip-components 1 -C src/linux-sunxi
 
-src/arm-trusted-firmware:
+src/linux-sunxi: orange-pi-5.9-20201019-1553.tar.gz
+	@echo "UNTAR linux-sunxi"
+	@mkdir src/linux-sunxi
+	@tar -xf orange-pi-5.9-20201019-1553.tar.gz --strip-components 1 -C src/linux-sunxi
+
+arm-trusted-firmware.tar.gz:
 	@echo "WGET  arm-trusted-firmware"
-	@mkdir src/arm-trusted-firmware
-	@wget https://github.com/ARM-software/arm-trusted-firmware/archive/50d8cf26dc57bb453b1a52be646140bfea4aa591.tar.gz
-	@tar -xvf 50d8cf26dc57bb453b1a52be646140bfea4aa591.tar.gz --strip-components 1 -C src/arm-trusted-firmware
+	@wget -O arm-trusted-firmware.tar.gz https://github.com/ARM-software/arm-trusted-firmware/archive/50d8cf26dc57bb453b1a52be646140bfea4aa591.tar.gz
 
-src/u-boot:
+src/arm-trusted-firmware: arm-trusted-firmware.tar.gz
+	@echo "UNTAR arm-trusted-firmware"
+	@mkdir src/arm-trusted-firmware
+	@tar -xf arm-trusted-firmware.tar.gz --strip-components 1 -C src/arm-trusted-firmware
+
+u-boot-2020.04.tar.bz2:
 	@echo "WGET  u-boot"
-	@mkdir src/u-boot
 	@wget ftp://ftp.denx.de/pub/u-boot/u-boot-2020.04.tar.bz2
-	@tar -xvf u-boot-2020.04.tar.bz2 --strip-components 1 -C src/u-boot
+
+src/u-boot: u-boot-2020.04.tar.bz2
+	@echo "UNTAR u-boot"
+	@mkdir src/u-boot
+	@tar -xf u-boot-2020.04.tar.bz2 --strip-components 1 -C src/u-boot
 	@cd src/u-boot && patch -p1 < ../u-boot-pinephone.patch
 
-src/busybox:
+busybox-1.32.0.tar.bz2:
 	@echo "WGET  busybox"
-	@mkdir src/busybox
 	@wget https://www.busybox.net/downloads/busybox-1.32.0.tar.bz2
-	@tar -xvf busybox-1.32.0.tar.bz2 --strip-components 1 -C src/busybox
+
+src/busybox: busybox-1.32.0.tar.bz2
+	@echo "UNTAR busybox"
+	@mkdir src/busybox
+	@tar -xf busybox-1.32.0.tar.bz2 --strip-components 1 -C src/busybox
 
 .PHONY: clean cleanfast
 
@@ -191,11 +210,15 @@ cleanfast:
 	@rm -vf *.apk
 	@rm -vf *.bin
 	@rm -vf *.cpio
-	@rm -vf *.gz
+	@rm -vf *.tar.gz
+	@rm -vf *.tar.bz2
 	@rm -vf *.scr
 	@rm -vf splash/*.gz
 
-clean: cleanfast
+cleansrc:
+	@rm -rf src/linux-rockchip src/linux-sunxi src/arm-trusted-firmware src/u-boot src/busybox
+
+clean: cleanfast cleansrc
 	@rm -vf kernel*.gz
 	@rm -vf initramfs/bin/busybox
 	@rm -vrf dtbs

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,13 @@ CROSS_FLAGS_BOOT = CROSS_COMPILE=aarch64-linux-gnu-
 all: pine64-pinephone.img.xz pine64-pinetab.img.xz
 
 
-pine64-pinephone.img: fat-pine64-pinephone.img u-boot-sunxi-with-spl.bin
+pine64-pinephone.img: fat-pine64-pinephone.img u-boot-sunxi-with-spl-pinephone.bin
 	rm -f $@
 	truncate --size 50M $@
 	parted -s $@ mktable msdos
 	parted -s $@ mkpart primary fat32 2048s 100%
 	parted -s $@ set 1 boot on
-	dd if=u-boot-sunxi-with-spl.bin of=$@ bs=8k seek=1
+	dd if=u-boot-sunxi-with-spl-pinephone.bin of=$@ bs=8k seek=1
 	dd if=fat-$@ of=$@ seek=1024 bs=1k
 
 fat-pine64-pinephone.img: initramfs-pine64-pinephone.gz kernel-sunxi.gz pine64-pinephone.scr dtbs/sunxi/sun50i-a64-pinephone-1.2.dtb
@@ -26,13 +26,13 @@ fat-pine64-pinephone.img: initramfs-pine64-pinephone.gz kernel-sunxi.gz pine64-p
 	@mcopy -i $@ initramfs-pine64-pinephone.gz ::initramfs.gz
 	@mcopy -i $@ pine64-pinephone.scr ::boot.scr
 
-pine64-pinetab.img: fat-pine64-pinetab.img u-boot-sunxi-with-spl.bin
+pine64-pinetab.img: fat-pine64-pinetab.img u-boot-sunxi-with-spl-pinetab.bin
 	rm -f $@
 	truncate --size 50M $@
 	parted -s $@ mktable msdos
 	parted -s $@ mkpart primary fat32 2048s 100%
 	parted -s $@ set 1 boot on
-	dd if=u-boot-sunxi-with-spl.bin of=$@ bs=8k seek=1
+	dd if=u-boot-sunxi-with-spl-pinetab.bin of=$@ bs=8k seek=1
 	dd if=fat-$@ of=$@ seek=1024 bs=1k
 
 fat-pine64-pinetab.img: initramfs-pine64-pinetab.gz kernel-sunxi.gz pine64-pinetab.scr dtbs/sunxi/sun50i-a64-pinetab.dtb
@@ -130,10 +130,17 @@ build/atf/sun50i_a64/bl31.bin: src/arm-trusted-firmware
 	@cd src/arm-trusted-firmware; make $(CROSS_FLAGS_BOOT) PLAT=sun50i_a64 bl31
 	@cp src/arm-trusted-firmware/build/sun50i_a64/release/bl31.bin "$@"
 
-u-boot-sunxi-with-spl.bin: build/atf/sun50i_a64/bl31.bin src/u-boot
+u-boot-sunxi-with-spl-pinephone.bin: build/atf/sun50i_a64/bl31.bin src/u-boot
 	@echo "MAKE  $@"
 	@mkdir -p build/u-boot/sun50i_a64
 	@BL31=../../../build/atf/sun50i_a64/bl31.bin $(MAKE) -C src/u-boot O=../../build/u-boot/sun50i_a64 $(CROSS_FLAGS_BOOT) pinephone_defconfig
+	@BL31=../../../build/atf/sun50i_a64/bl31.bin $(MAKE) -C src/u-boot O=../../build/u-boot/sun50i_a64 $(CROSS_FLAGS_BOOT) ARCH=arm all
+	@cp build/u-boot/sun50i_a64/u-boot-sunxi-with-spl.bin "$@"
+
+u-boot-sunxi-with-spl-pinetab.bin: build/atf/sun50i_a64/bl31.bin src/u-boot
+	@echo "MAKE  $@"
+	@mkdir -p build/u-boot/sun50i_a64
+	@BL31=../../../build/atf/sun50i_a64/bl31.bin $(MAKE) -C src/u-boot O=../../build/u-boot/sun50i_a64 $(CROSS_FLAGS_BOOT) pinetab_defconfig
 	@BL31=../../../build/atf/sun50i_a64/bl31.bin $(MAKE) -C src/u-boot O=../../build/u-boot/sun50i_a64 $(CROSS_FLAGS_BOOT) ARCH=arm all
 	@cp build/u-boot/sun50i_a64/u-boot-sunxi-with-spl.bin "$@"
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,6 @@ The dependencies are:
 - mtools
 
 ```shell-session
-$ git submodule update --init --recursive
-Downloads the projects to build
-
 $ make -j8 pine64-pinephone.img.xz
 Builds everything needed for the pinephone image...
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ The dependencies are:
 - mtools
 
 ```shell-session
+$ make src
+Downloads & unpacks the projects to build
+
 $ make -j8 pine64-pinephone.img.xz
 Builds everything needed for the pinephone image...
 

--- a/src/0001-isun50i-a64-Add-PinePhone-DTS-and-defconfig.patch
+++ b/src/0001-isun50i-a64-Add-PinePhone-DTS-and-defconfig.patch
@@ -38,7 +38,7 @@ index 0000000000..dc4ab6b434
 +/dts-v1/;
 +
 +#include "sun50i-a64.dtsi"
-+#include "sun50i-a64-cpu-opp.dtsi"
++/* #include "sun50i-a64-cpu-opp.dtsi" */
 +
 +#include <dt-bindings/gpio/gpio.h>
 +#include <dt-bindings/input/input.h>
@@ -74,7 +74,7 @@ index 0000000000..dc4ab6b434
 +		#address-cells = <1>;
 +		#size-cells = <0>;
 +
-+		/* Rear camera */
++		/* Rear camera */ /*
 +		ov5640: camera@3c {
 +			compatible = "ovti,ov5640";
 +			reg = <0x3c>;
@@ -86,20 +86,20 @@ index 0000000000..dc4ab6b434
 +			AVDD-supply = <&reg_dldo3>;
 +			DOVDD-supply = <&reg_aldo1>;
 +			DVDD-supply = <&reg_eldo3>;
-+			reset-gpios = <&pio 4 14 GPIO_ACTIVE_LOW>; /* PE14 */
-+			powerdown-gpios = <&pio 4 15 GPIO_ACTIVE_HIGH>; /* PE15 */
++			reset-gpios = <&pio 4 14 GPIO_ACTIVE_LOW>; /* PE14 */ /*
++			powerdown-gpios = <&pio 4 15 GPIO_ACTIVE_HIGH>; /* PE15 */ /*
 +
 +			port {
 +				ov5640_ep: endpoint {
 +					remote-endpoint = <&csi_ep>;
 +					bus-width = <8>;
-+					hsync-active = <1>; /* Active high */
-+					vsync-active = <0>; /* Active low */
-+					data-active = <1>;  /* Active high */
-+					pclk-sample = <1>;  /* Rising */
++					hsync-active = <1>; /* Active high */ /*
++					vsync-active = <0>; /* Active low */ /*
++					data-active = <1>;  /* Active high */ /*
++					pclk-sample = <1>;  /* Rising */ /*
 +				};
 +			};
-+		};
++		}; */
 +	};
 +
 +	speaker_amp: audio-amplifier {
@@ -124,14 +124,14 @@ index 0000000000..dc4ab6b434
 +	};
 +};
 +
-+&codec {
++/* &codec {
 +	status = "okay";
 +};
 +
 +&codec_analog {
 +	cpvdd-supply = <&reg_eldo1>;
 +	status = "okay";
-+};
++}; */
 +
 +&cpu0 {
 +	cpu-supply = <&reg_dcdc2>;
@@ -149,7 +149,7 @@ index 0000000000..dc4ab6b434
 +	cpu-supply = <&reg_dcdc2>;
 +};
 +
-+&csi {
++/* &csi {
 +	status = "okay";
 +
 +	port {
@@ -159,10 +159,10 @@ index 0000000000..dc4ab6b434
 +		csi_ep: endpoint {
 +			remote-endpoint = <&ov5640_ep>;
 +			bus-width = <8>;
-+			hsync-active = <1>; /* Active high */
-+			vsync-active = <0>; /* Active low */
-+			data-active = <1>;  /* Active high */
-+			pclk-sample = <1>;  /* Rising */
++			hsync-active = <1>; /* Active high */ /*
++			vsync-active = <0>; /* Active low */ /*
++			data-active = <1>;  /* Active high */ /*
++			pclk-sample = <1>;  /* Rising */ /*
 +		};
 +	};
 +};
@@ -189,10 +189,10 @@ index 0000000000..dc4ab6b434
 +		avdd-supply = <&reg_dc1sw>;
 +		dvdd-supply = <&reg_dc1sw>;
 +		cvdd-supply = <&reg_ldo_io1>;
-+		reset-gpios = <&pio 3 24 GPIO_ACTIVE_HIGH>; /* PD24 */
++		reset-gpios = <&pio 3 24 GPIO_ACTIVE_HIGH>; /* PD24 */ /*
 +		backlight = <&backlight>;
 +	};
-+};
++}; */
 +
 +&ehci0 {
 +	status = "okay";
@@ -226,7 +226,7 @@ index 0000000000..dc4ab6b434
 +	/* TODO: add Bochs BMA223 accelerometer here */
 +};
 +
-+&lradc {
++/* &lradc {
 +	vref-supply = <&reg_aldo3>;
 +	status = "okay";
 +
@@ -243,7 +243,7 @@ index 0000000000..dc4ab6b434
 +		channel = <0>;
 +		voltage = <400000>;
 +	};
-+};
++}; */
 +
 +&mixer1 {
 +	status = "okay";
@@ -307,13 +307,13 @@ index 0000000000..dc4ab6b434
 +
 +#include "axp803.dtsi"
 +
-+&ac_power_supply {
++/* &ac_power_supply {
 +	status = "okay";
 +};
 +
 +&battery_power_supply {
 +	status = "okay";
-+};
++}; */
 +
 +&reg_aldo1 {
 +	regulator-min-microvolt = <2800000>;
@@ -353,7 +353,7 @@ index 0000000000..dc4ab6b434
 +	regulator-name = "vdd-cpux";
 +};
 +
-+/* DCDC3 is polyphased with DCDC2 */
++/* DCDC3 is polyphased with DCDC2 */ /*
 +
 +&reg_dcdc5 {
 +	regulator-always-on;
@@ -444,7 +444,7 @@ index 0000000000..dc4ab6b434
 +	regulator-name = "vcc-rtc";
 +};
 +
-+&sound {
++/* &sound {
 +	status = "okay";
 +	simple-audio-card,aux-devs = <&codec_analog>, <&speaker_amp>;
 +	simple-audio-card,widgets = "Microphone", "Internal Microphone Left",
@@ -465,7 +465,7 @@ index 0000000000..dc4ab6b434
 +			"MIC1", "Internal Microphone Left",
 +			"Internal Microphone Right", "HBIAS",
 +			"MIC2", "Internal Microphone Right";
-+};
++}; */
 +
 +&uart0 {
 +	pinctrl-names = "default";
@@ -478,17 +478,17 @@ index 0000000000..dc4ab6b434
 +	status = "okay";
 +};
 +
-+&usb_power_supply {
++/* &usb_power_supply {
 +	status = "okay";
 +};
 +
 +&usbphy {
-+	usb0_id_det-gpios = <&pio 7 9 GPIO_ACTIVE_HIGH>; /* PH9 */
++	usb0_id_det-gpios = <&pio 7 9 GPIO_ACTIVE_HIGH>; /* PH9 */ /*
 +	usb0_vbus_power-supply = <&usb_power_supply>;
 +	usb0_vbus-supply = <&reg_drivevbus>;
 +	usb1_vbus-supply = <&reg_ldo_io0>;
 +	status = "okay";
-+};
++}; */
 diff --git a/configs/pinetab_defconfig b/configs/pinetab_defconfig
 new file mode 100644
 index 0000000000..350465a425

--- a/src/0001-isun50i-a64-Add-PinePhone-DTS-and-defconfig.patch
+++ b/src/0001-isun50i-a64-Add-PinePhone-DTS-and-defconfig.patch
@@ -1,0 +1,510 @@
+From cd8587734d300ea43e1328f8bfe892f82fd05915 Mon Sep 17 00:00:00 2001
+From: Javier Palacios <javiplx@gmail.com>
+Date: Tue, 29 Dec 2020 14:04:26 +0100
+Subject: [PATCH] isun50i: a64: Add PinePhone DTS and defconfig
+
+---
+ arch/arm/dts/Makefile               |   1 +
+ arch/arm/dts/sun50i-a64-pinetab.dts | 460 ++++++++++++++++++++++++++++
+ configs/pinetab_defconfig           |  10 +
+ 3 files changed, 471 insertions(+)
+ create mode 100644 arch/arm/dts/sun50i-a64-pinetab.dts
+ create mode 100644 configs/pinetab_defconfig
+
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index 4dd7a0c705..56637075e8 100644
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -574,6 +574,7 @@ dtb-$(CONFIG_MACH_SUN50I) += \
+ 	sun50i-a64-pine64.dtb \
+ 	sun50i-a64-pinebook.dtb \
+ 	sun50i-a64-pinephone.dtb \
++	sun50i-a64-pinetab.dtb \
+ 	sun50i-a64-sopine-baseboard.dtb \
+ 	sun50i-a64-teres-i.dtb
+ dtb-$(CONFIG_MACH_SUN9I) += \
+diff --git a/arch/arm/dts/sun50i-a64-pinetab.dts b/arch/arm/dts/sun50i-a64-pinetab.dts
+new file mode 100644
+index 0000000000..dc4ab6b434
+--- /dev/null
++++ b/arch/arm/dts/sun50i-a64-pinetab.dts
+@@ -0,0 +1,460 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (C) 2019 Icenowy Zheng <icenowy@aosc.xyz>
++ *
++ */
++
++/dts-v1/;
++
++#include "sun50i-a64.dtsi"
++#include "sun50i-a64-cpu-opp.dtsi"
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/pwm/pwm.h>
++
++/ {
++	model = "PineTab";
++	compatible = "pine64,pinetab", "allwinner,sun50i-a64";
++
++	aliases {
++		serial0 = &uart0;
++		ethernet0 = &rtl8723cs;
++	};
++
++	backlight: backlight {
++		compatible = "pwm-backlight";
++		pwms = <&pwm 0 50000 PWM_POLARITY_INVERTED>;
++		brightness-levels = <0 16 18 20 22 24 26 29 32 35 38 42 46 51 56 62 68 75 83 91 100>;
++		default-brightness-level = <15>;
++		enable-gpios = <&pio 3 23 GPIO_ACTIVE_HIGH>; /* PD23 */
++		power-supply = <&vdd_bl>;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	i2c-csi {
++		compatible = "i2c-gpio";
++		sda-gpios = <&pio 4 13 GPIO_ACTIVE_HIGH>; /* PE13 */
++		scl-gpios = <&pio 4 12 GPIO_ACTIVE_HIGH>; /* PE12 */
++		i2c-gpio,delay-us = <5>;
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		/* Rear camera */
++		ov5640: camera@3c {
++			compatible = "ovti,ov5640";
++			reg = <0x3c>;
++			pinctrl-names = "default";
++			pinctrl-0 = <&csi_mclk_pin>;
++			clocks = <&ccu CLK_CSI_MCLK>;
++			clock-names = "xclk";
++
++			AVDD-supply = <&reg_dldo3>;
++			DOVDD-supply = <&reg_aldo1>;
++			DVDD-supply = <&reg_eldo3>;
++			reset-gpios = <&pio 4 14 GPIO_ACTIVE_LOW>; /* PE14 */
++			powerdown-gpios = <&pio 4 15 GPIO_ACTIVE_HIGH>; /* PE15 */
++
++			port {
++				ov5640_ep: endpoint {
++					remote-endpoint = <&csi_ep>;
++					bus-width = <8>;
++					hsync-active = <1>; /* Active high */
++					vsync-active = <0>; /* Active low */
++					data-active = <1>;  /* Active high */
++					pclk-sample = <1>;  /* Rising */
++				};
++			};
++		};
++	};
++
++	speaker_amp: audio-amplifier {
++		compatible = "simple-audio-amplifier";
++		enable-gpios = <&pio 7 7 GPIO_ACTIVE_HIGH>; /* PH7 */
++		sound-name-prefix = "Speaker Amp";
++	};
++
++	vdd_bl: regulator@0 {
++		compatible = "regulator-fixed";
++		regulator-name = "bl-3v3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		gpio = <&pio 7 6 GPIO_ACTIVE_HIGH>; /* PH6 */
++		enable-active-high;
++	};
++
++	wifi_pwrseq: wifi_pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		reset-gpios = <&r_pio 0 2 GPIO_ACTIVE_LOW>; /* PL2 */
++		post-power-on-delay-ms = <200>;
++	};
++};
++
++&codec {
++	status = "okay";
++};
++
++&codec_analog {
++	cpvdd-supply = <&reg_eldo1>;
++	status = "okay";
++};
++
++&cpu0 {
++	cpu-supply = <&reg_dcdc2>;
++};
++
++&cpu1 {
++	cpu-supply = <&reg_dcdc2>;
++};
++
++&cpu2 {
++	cpu-supply = <&reg_dcdc2>;
++};
++
++&cpu3 {
++	cpu-supply = <&reg_dcdc2>;
++};
++
++&csi {
++	status = "okay";
++
++	port {
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		csi_ep: endpoint {
++			remote-endpoint = <&ov5640_ep>;
++			bus-width = <8>;
++			hsync-active = <1>; /* Active high */
++			vsync-active = <0>; /* Active low */
++			data-active = <1>;  /* Active high */
++			pclk-sample = <1>;  /* Rising */
++		};
++	};
++};
++
++&dai {
++	status = "okay";
++};
++
++&de {
++	status = "okay";
++};
++
++&dphy {
++	status = "okay";
++};
++
++&dsi {
++	vcc-dsi-supply = <&reg_dldo1>;
++	status = "okay";
++
++	panel@0 {
++		compatible = "feixin,k101-im2ba02";
++		reg = <0>;
++		avdd-supply = <&reg_dc1sw>;
++		dvdd-supply = <&reg_dc1sw>;
++		cvdd-supply = <&reg_ldo_io1>;
++		reset-gpios = <&pio 3 24 GPIO_ACTIVE_HIGH>; /* PD24 */
++		backlight = <&backlight>;
++	};
++};
++
++&ehci0 {
++	status = "okay";
++};
++
++&ehci1 {
++	status = "okay";
++};
++
++&i2c0 {
++	status = "okay";
++
++	touchscreen@5d {
++		compatible = "goodix,gt9271";
++		reg = <0x5d>;
++		interrupt-parent = <&pio>;
++		interrupts = <7 4 IRQ_TYPE_LEVEL_HIGH>; /* PH4 */
++		irq-gpios = <&pio 7 4 GPIO_ACTIVE_HIGH>; /* PH4 */
++		reset-gpios = <&pio 7 8 GPIO_ACTIVE_HIGH>; /* PH8 */
++		AVDD28-supply = <&reg_ldo_io1>;
++	};
++};
++
++&i2c0_pins {
++	bias-pull-up;
++};
++
++&i2c1 {
++	status = "okay";
++
++	/* TODO: add Bochs BMA223 accelerometer here */
++};
++
++&lradc {
++	vref-supply = <&reg_aldo3>;
++	status = "okay";
++
++	button-200 {
++		label = "Volume Up";
++		linux,code = <KEY_VOLUMEUP>;
++		channel = <0>;
++		voltage = <200000>;
++	};
++
++	button-400 {
++		label = "Volume Down";
++		linux,code = <KEY_VOLUMEDOWN>;
++		channel = <0>;
++		voltage = <400000>;
++	};
++};
++
++&mixer1 {
++	status = "okay";
++};
++
++&mmc0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mmc0_pins>;
++	vmmc-supply = <&reg_dcdc1>;
++	cd-gpios = <&pio 5 6 GPIO_ACTIVE_LOW>;
++	disable-wp;
++	bus-width = <4>;
++	status = "okay";
++};
++
++&mmc1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mmc1_pins>;
++	vmmc-supply = <&reg_dldo4>;
++	vqmmc-supply = <&reg_eldo1>;
++	mmc-pwrseq = <&wifi_pwrseq>;
++	bus-width = <4>;
++	non-removable;
++	status = "okay";
++
++	rtl8723cs: wifi@1 {
++		reg = <1>;
++	};
++};
++
++&mmc2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mmc2_pins>;
++	vmmc-supply = <&reg_dcdc1>;
++	vqmmc-supply = <&reg_dcdc1>;
++	bus-width = <8>;
++	non-removable;
++	cap-mmc-hw-reset;
++	status = "okay";
++};
++
++&ohci0 {
++	status = "okay";
++};
++
++&pwm {
++	status = "okay";
++};
++
++&r_rsb {
++	status = "okay";
++
++	axp803: pmic@3a3 {
++		compatible = "x-powers,axp803";
++		reg = <0x3a3>;
++		interrupt-parent = <&r_intc>;
++		interrupts = <0 IRQ_TYPE_LEVEL_LOW>;
++		x-powers,drive-vbus-en;
++	};
++};
++
++#include "axp803.dtsi"
++
++&ac_power_supply {
++	status = "okay";
++};
++
++&battery_power_supply {
++	status = "okay";
++};
++
++&reg_aldo1 {
++	regulator-min-microvolt = <2800000>;
++	regulator-max-microvolt = <2800000>;
++	regulator-name = "dovdd-csi";
++};
++
++&reg_aldo2 {
++	regulator-always-on;
++	regulator-min-microvolt = <1800000>;
++	regulator-max-microvolt = <3300000>;
++	regulator-name = "vcc-pl";
++};
++
++&reg_aldo3 {
++	regulator-always-on;
++	regulator-min-microvolt = <2700000>;
++	regulator-max-microvolt = <3300000>;
++	regulator-name = "vcc-pll-avcc";
++};
++
++&reg_dc1sw {
++	regulator-name = "vcc-lcd";
++};
++
++&reg_dcdc1 {
++	regulator-always-on;
++	regulator-min-microvolt = <3300000>;
++	regulator-max-microvolt = <3300000>;
++	regulator-name = "vcc-3v3";
++};
++
++&reg_dcdc2 {
++	regulator-always-on;
++	regulator-min-microvolt = <1000000>;
++	regulator-max-microvolt = <1300000>;
++	regulator-name = "vdd-cpux";
++};
++
++/* DCDC3 is polyphased with DCDC2 */
++
++&reg_dcdc5 {
++	regulator-always-on;
++	regulator-min-microvolt = <1200000>;
++	regulator-max-microvolt = <1200000>;
++	regulator-name = "vcc-dram";
++};
++
++&reg_dcdc6 {
++	regulator-always-on;
++	regulator-min-microvolt = <1100000>;
++	regulator-max-microvolt = <1100000>;
++	regulator-name = "vdd-sys";
++};
++
++&reg_dldo1 {
++	regulator-always-on;
++	regulator-min-microvolt = <3300000>;
++	regulator-max-microvolt = <3300000>;
++	regulator-name = "vcc-hdmi-dsi-sensor";
++};
++
++&reg_dldo3 {
++	regulator-min-microvolt = <2800000>;
++	regulator-max-microvolt = <2800000>;
++	regulator-name = "avdd-csi";
++};
++
++&reg_dldo4 {
++	regulator-min-microvolt = <3300000>;
++	regulator-max-microvolt = <3300000>;
++	regulator-name = "vcc-wifi";
++};
++
++&reg_drivevbus {
++	regulator-name = "usb0-vbus";
++	status = "okay";
++};
++
++&reg_eldo1 {
++	regulator-always-on;
++	regulator-min-microvolt = <1800000>;
++	regulator-max-microvolt = <1800000>;
++	regulator-name = "cpvdd";
++};
++
++&reg_eldo2 {
++	regulator-min-microvolt = <1800000>;
++	regulator-max-microvolt = <1800000>;
++	regulator-name = "vcca-1v8";
++};
++
++&reg_eldo3 {
++	regulator-min-microvolt = <1800000>;
++	regulator-max-microvolt = <1800000>;
++	regulator-name = "dvdd-1v8-csi";
++};
++
++&reg_fldo1 {
++	regulator-min-microvolt = <1200000>;
++	regulator-max-microvolt = <1200000>;
++	regulator-name = "vcc-1v2-hsic";
++};
++
++&reg_fldo2 {
++	regulator-always-on;
++	regulator-min-microvolt = <1100000>;
++	regulator-max-microvolt = <1100000>;
++	regulator-name = "vdd-cpus";
++};
++
++&reg_ldo_io0 {
++	regulator-min-microvolt = <3300000>;
++	regulator-max-microvolt = <3300000>;
++	regulator-name = "vcc-usb";
++	status = "okay";
++};
++
++&reg_ldo_io1 {
++	regulator-min-microvolt = <3300000>;
++	regulator-max-microvolt = <3300000>;
++	regulator-enable-ramp-delay = <3500000>;
++	regulator-name = "vcc-touchscreen";
++	status = "okay";
++};
++
++&reg_rtc_ldo {
++	regulator-name = "vcc-rtc";
++};
++
++&sound {
++	status = "okay";
++	simple-audio-card,aux-devs = <&codec_analog>, <&speaker_amp>;
++	simple-audio-card,widgets = "Microphone", "Internal Microphone Left",
++				    "Microphone", "Internal Microphone Right",
++				    "Headphone", "Headphone Jack",
++				    "Speaker", "Internal Speaker";
++	simple-audio-card,routing =
++			"Left DAC", "AIF1 Slot 0 Left",
++			"Right DAC", "AIF1 Slot 0 Right",
++			"Speaker Amp INL", "LINEOUT",
++			"Speaker Amp INR", "LINEOUT",
++			"Internal Speaker", "Speaker Amp OUTL",
++			"Internal Speaker", "Speaker Amp OUTR",
++			"Headphone Jack", "HP",
++			"AIF1 Slot 0 Left ADC", "Left ADC",
++			"AIF1 Slot 0 Right ADC", "Right ADC",
++			"Internal Microphone Left", "MBIAS",
++			"MIC1", "Internal Microphone Left",
++			"Internal Microphone Right", "HBIAS",
++			"MIC2", "Internal Microphone Right";
++};
++
++&uart0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart0_pb_pins>;
++	status = "okay";
++};
++
++&usb_otg {
++	dr_mode = "otg";
++	status = "okay";
++};
++
++&usb_power_supply {
++	status = "okay";
++};
++
++&usbphy {
++	usb0_id_det-gpios = <&pio 7 9 GPIO_ACTIVE_HIGH>; /* PH9 */
++	usb0_vbus_power-supply = <&usb_power_supply>;
++	usb0_vbus-supply = <&reg_drivevbus>;
++	usb1_vbus-supply = <&reg_ldo_io0>;
++	status = "okay";
++};
+diff --git a/configs/pinetab_defconfig b/configs/pinetab_defconfig
+new file mode 100644
+index 0000000000..350465a425
+--- /dev/null
++++ b/configs/pinetab_defconfig
+@@ -0,0 +1,10 @@
++CONFIG_ARM=y
++CONFIG_ARCH_SUNXI=y
++CONFIG_SPL=y
++CONFIG_MACH_SUN50I=y
++CONFIG_SUNXI_DRAM_LPDDR3_STOCK=y
++CONFIG_DRAM_CLK=552
++CONFIG_DRAM_ZQ=3881949
++CONFIG_MMC_SUNXI_SLOT_EXTRA=2
++CONFIG_DEFAULT_DEVICE_TREE="sun50i-a64-pinetab"
++CONFIG_BOOTDELAY=10
+-- 
+2.20.1
+


### PR DESCRIPTION
Borrows the pinetab device tree from pine64-org u-boot repository to create a pinetab specific first stage bootloader. At this point, the only real difference is that the _model: PinePhone_ message is not shown anymore (if looking at serial console). It is not clear which is the right dts file for pinetab, and it must anyway be trimmed (the panel section in particular), so this is still a kind of exercise.