### PR TITLE
setup_usb_configfs: Make it possible to choose the used UDC

### DIFF
--- a/initramfs/init_functions.sh
+++ b/initramfs/init_functions.sh
@@ -73,8 +73,12 @@ setup_usb_configfs() {
 		fatal_error "No USB Device Controller available"
 	fi
 
+	if [ -z "$UDC" ]; then
+		UDC="$(ls /sys/class/udc)"
+	fi
+
 	# shellcheck disable=SC2005
-	echo "$(ls /sys/class/udc)" > $CONFIGFS/g1/UDC || ( fatal_error "Couldn't write to UDC" )
+	echo "$UDC" > $CONFIGFS/g1/UDC || ( fatal_error "Couldn't write to UDC" )
 }
 
 setup_telnetd() {


### PR DESCRIPTION
Some devices may have more than one UDC available.

---

I did it while working on the Librem 5 port, but it turned out to be unnecessary with correctly configured kernel ;) Posting it anyway since it may be useful for other devices in the future and generally seems like a reasonable thing to do.