### PR TITLE
Update Dependency list and add install commands for Arch and Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ The dependencies are:
 - aarch64-linux-gnu- toolchain
 - u-boot tools
 - mtools
+- bison
+- flex
+- cpio
+
+#### To install the build dependencies in Arch :
+```bash
+sudo pacman -S aarch64-linux-gnu-gcc uboot-tools mtools cpio bison flex
+```
+
+#### To install the build dependencies in Ubuntu/Debian :
+```bash
+sudo apt install gcc-aarch64-linux-gnu u-boot-tools mtools cpio bison flex
+```
 
 Additional dependencies for the Purism Librem 5:
 - arm-none-eabi- toolchain

--- a/README.md
+++ b/README.md
@@ -49,15 +49,24 @@ The dependencies are:
 - bison
 - flex
 - cpio
+- make
+- wget
+- swig
+- bc
+- python3
+- python3 distutils
+- parted
+- mkfs.fat
+- udev
 
 #### To install the build dependencies in Arch :
 ```bash
-sudo pacman -S aarch64-linux-gnu-gcc uboot-tools mtools cpio bison flex
+sudo pacman -S aarch64-linux-gnu-gcc uboot-tools mtools cpio bison flex make wget swig bc python python-distlib parted dosfstools
 ```
 
 #### To install the build dependencies in Ubuntu/Debian :
 ```bash
-sudo apt install gcc-aarch64-linux-gnu u-boot-tools mtools cpio bison flex
+sudo apt install gcc-aarch64-linux-gnu u-boot-tools mtools cpio bison flex make wget swig bc python3 python3-distutils parted dosfstools udev
 ```
 
 Additional dependencies for the Purism Librem 5:


### PR DESCRIPTION
Hello,

The README was missing some core dependencies which are required to build Jumpdrive.

This PR  adds the remaining dependencies to the list and provides install commands for Arch Linux and Ubuntu/Debian for convenience.