### PR TITLE
Clarify charging image for PinePhone

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Then use dd to flash the image to an SD card. Jumpdrive is pretty small, so ther
 
 Insert the SD card to the device, then boot it up, you should get a nice splash screen and you should see a new storage device after you plug the device to USB.
 
-With the device plugged in, you can now flash a distro, or fix a unbootable installation.
+With the device plugged in, you can now flash a distro, fix an unbootable installation or only charge quickly your PinePhone using the image pine64-pinephone-charging.img.
 
 **WARNING:**
 In case eMMC isn't showing up try to charge your battery and try again. There are reports of people not being able to flash to eMMC with discharged battery.


### PR DESCRIPTION
This little commit tries to clarify the charging image for the PinePhone to avoid having surprises and people wondering about why Jumpdrive won't boot.

Resolves the issue #66.