### PR TITLE
Expose boot eMMC partitions and mark them as bootable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /*.img
 /*.apk
 /initramfs/bin/busybox
+/initramfs/bin/mmc
 /initramfs-*
 /build
 /dtbs
@@ -10,6 +11,7 @@
 /src/linux-librem5
 /src/linux-sdm845
 /src/busybox
+/src/mmc-utils
 /src/u-boot
 /src/u-boot-pocketpc
 /src/u-boot-librem5

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+CC = aarch64-linux-gnu-gcc
 CROSS_FLAGS = ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu-
 CROSS_FLAGS_BOOT = CROSS_COMPILE=aarch64-linux-gnu-
 
@@ -119,12 +120,18 @@ initramfs/bin/busybox: src/busybox src/busybox_config
 	@cp src/busybox_config build/busybox/.config
 	@$(MAKE) -C src/busybox O=../../build/busybox $(CROSS_FLAGS)
 	@cp build/busybox/busybox initramfs/bin/busybox
+
+initramfs/bin/mmc-utils: src/mmc-utils
+	@echo "MAKE  $@"
+	@mkdir -p build/mmc-utils
+	@$(MAKE) -C src/mmc-utils O=../../build/mmc-utils CFLAGS="-Wno-error -static" CC=$(CC)
+	@cp src/mmc-utils/mmc initramfs/bin/mmc
 	
 splash/%.ppm.gz: splash/%.ppm
 	@echo "GZ    $@"
 	@gzip < $< > $@
 	
-initramfs-%.cpio: initramfs/bin/busybox initramfs/init initramfs/init_functions.sh splash/%.ppm.gz splash/%-error.ppm.gz
+initramfs-%.cpio: initramfs/bin/busybox initramfs/bin/mmc-utils initramfs/init initramfs/init_functions.sh splash/%.ppm.gz splash/%-error.ppm.gz
 	@echo "CPIO  $@"
 	@rm -rf initramfs-$*
 	@cp -r initramfs initramfs-$*
@@ -308,6 +315,12 @@ src/busybox:
 	@mkdir src/busybox
 	@wget https://www.busybox.net/downloads/busybox-1.32.0.tar.bz2
 	@tar -xf busybox-1.32.0.tar.bz2 --strip-components 1 -C src/busybox
+
+src/mmc-utils:
+	@echo "WGET  mmc-utils"
+	@mkdir src/mmc-utils
+	@wget https://git.kernel.org/pub/scm/utils/mmc/mmc-utils.git/snapshot/mmc-utils-0eea71e4f22a837ed59e607743767df2d038825e.tar.gz
+	@tar -xf mmc-utils-0eea71e4f22a837ed59e607743767df2d038825e.tar.gz --strip-components 1 -C src/mmc-utils
 
 .PHONY: clean cleanfast purism-librem5
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ The dependencies are:
 - aarch64-linux-gnu- toolchain
 - u-boot tools
 - mtools
+- swig
+- dtc
+- cpio
+- bc
 
 Additional dependencies for the Purism Librem 5:
 - arm-none-eabi- toolchain
@@ -72,5 +76,6 @@ Generates an image for every supported platform in parallel
 - [Busybox](https://busybox.net) - which is [GPLv2](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html).
 - [postmarketOS](https://postmarketos.org) scripts - which is [GPLv2](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html).
 - [Pine64's kernel fork](https://gitlab.com/pine64-org/linux) - which is [GPLv2](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html).
-- [U-Boot](https://github.com/u-boot/u-boot) - which has [multiple licenses](https://github.com/u-boot/u-boot/tree/master/Licenses)
+- [U-Boot](https://github.com/u-boot/u-boot) - which has [multiple licenses](https://github.com/u-boot/u-boot/tree/master/Licenses).
+- [mmc-utils](https://www.kernel.org/doc/html/latest/driver-api/mmc/mmc-tools.html) - which is [GPLv2](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html).
 

--- a/src/info-pine64-pinephone.sh
+++ b/src/info-pine64-pinephone.sh
@@ -2,6 +2,7 @@ PLATFORM=pine64-pinephone
 MANUFACTURER=Pine64
 PRODUCT=PinePhone
 EMMC=/dev/mmcblk2
+EMMC_BOOT=/dev/mmcblk2boot1
 SD=/dev/mmcblk0
 LED=red\:indicator
 TRIGGER=mmc2


### PR DESCRIPTION
Can be used to install for example Tow-Boot from a host PC.

The partition should be marked as bootable as well but it has been untested