### PR TITLE
Update linux-sdm845 to 5.16.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,8 +275,8 @@ src/linux-librem5:
 src/linux-sdm845:
 	@echo "WGET linux-sdm845"
 	@mkdir src/linux-sdm845
-	@wget -c https://gitlab.com/sdm845-mainline/linux/-/archive/b7a1e57f78d690d02aff902114bf2f6ca978ecfe/linux-b7a1e57f78d690d02aff902114bf2f6ca978ecfe.tar.gz
-	@tar -xf linux-b7a1e57f78d690d02aff902114bf2f6ca978ecfe.tar.gz --strip-components 1 -C src/linux-sdm845
+	@wget -c https://gitlab.com/sdm845-mainline/linux/-/archive/77c0e13ec39469a2e3057e1c1853f425626b50e4/linux-77c0e13ec39469a2e3057e1c1853f425626b50e4.tar.gz
+	@tar -xf linux-77c0e13ec39469a2e3057e1c1853f425626b50e4.tar.gz --strip-components 1 -C src/linux-sdm845
 
 src/arm-trusted-firmware:
 	@echo "WGET  arm-trusted-firmware"


### PR DESCRIPTION
What the title says. Fixes crashes above 6GB on Oneplus devices aka #58 