### PR TITLE
librem5: workaround atf bug on some compilers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,6 +296,7 @@ src/u-boot-librem5:
 	@mkdir src/u-boot-librem5
 	@wget https://source.puri.sm/Librem5/u-boot-builder/-/archive/3b1c7d957f46c87c6cdd71cd8dab7c84aca26570/u-boot-builder-3b1c7d957f46c87c6cdd71cd8dab7c84aca26570.tar.gz
 	@tar -xf u-boot-builder-3b1c7d957f46c87c6cdd71cd8dab7c84aca26570.tar.gz --strip-components 1 -C src/u-boot-librem5
+	@cd src/u-boot-librem5 && patch -p1 < ../librem5-atf-bug.patch
 
 src/u-boot-pocketpc:
 	@echo "WGET  u-boot-pocketpc"

--- a/src/librem5-atf-bug.patch
+++ b/src/librem5-atf-bug.patch
@@ -1,0 +1,18 @@
+diff --git a/build_uboot.sh b/build_uboot.sh
+index d9fb650..9a4b428 100755
+--- a/build_uboot.sh
++++ b/build_uboot.sh
+@@ -101,8 +101,13 @@ function build_atf()
+         git clone "${ATF_REPO}"
+     fi
+     cd "${ATF_DIR}"
++    git reset --hard
++    git clean -f -d
+     git checkout "${ATF_BRANCH}"
+ 
++    # Remove -Werror to workaround a compiler bug
++    sed -i 's/-Werror//g' Makefile
++
+     make PLAT="${ATF_PLAT}" CROSS_COMPILE="${CROSS_COMPILER}"  bl31
+     
+     cd "${CWD}"


### PR DESCRIPTION
According to @craftyguy, there's a bug with GCC 12.1 that caused the compilation to fail:

```
+ make PLAT=imx8mq CROSS_COMPILE=aarch64-linux-gnu- bl31
make[1]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
make[1]: Entering directory '/tmp/Jumpdrive/build/u-boot/librem5/arm-trusted-firmware'
  CC      plat/imx/imx8mq/imx8mq_bl31_setup.c
  CC      plat/imx/imx8mq/src.c
In file included from plat/imx/imx8mq/src.c:13:
In function 'mmio_read_8',
    inlined from 'imx_soc_handler' at plat/imx/imx8mq/src.c:59:16:
include/lib/mmio.h:19:16: error: array subscript 0 is outside array bounds of 'volatile uint8_t[0]' {aka 'volatile unsigned char[]'} [-Werror=array-bounds]
   19 |         return *(volatile uint8_t*)addr;
      |                ^~~~~~~~~~~~~~~~~~~~~~~~
In function 'mmio_read_8',
    inlined from 'imx_soc_handler' at plat/imx/imx8mq/src.c:61:17:
include/lib/mmio.h:19:16: error: array subscript 0 is outside array bounds of 'volatile uint8_t[0]' {aka 'volatile unsigned char[]'} [-Werror=array-bounds]
   19 |         return *(volatile uint8_t*)addr;
      |                ^~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[1]: *** [Makefile:711: build/imx8mq/release/bl31/src.o] Error 1
make[1]: Leaving directory '/tmp/Jumpdrive/build/u-boot/librem5/arm-trusted-firmware'
make: *** [Makefile:247: u-boot-librem5.bin] Error 2
```