### PR TITLE
Pass purism-librem5.lst to uuu relative to boot-purism-librem5.sh

### DIFF
--- a/src/boot-purism-librem5.sh
+++ b/src/boot-purism-librem5.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 
-uuu purism-librem5.lst
+REPOROOT="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+uuu $REPOROOT/purism-librem5.lst


### PR DESCRIPTION
This modification passes purism-librem5.lst to uuu relative to the location of boot-purism-librem5.sh rather than from pwd. In this way, a user does not have to cd into the directory containing boot-purism-librem5.sh for uuu to read purism-librem5.lst properly.